### PR TITLE
Workaround for test running problems with thread unsafe trireme call

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -68,6 +68,10 @@ idea {
     }
 }
 
+test{
+    maxParallelForks = 1
+}
+
 cobertura {
     coverageFormats = ['html', 'xml']
     coverageSourceDirs = sourceSets.main.groovy.srcDirs


### PR DESCRIPTION
This would make #8 easier to solve.

When more then one thread reads from script. Bad things happens, exception is thrown even in case of success.
