### PR TITLE
modify resource tasks to not chain input properties

### DIFF
--- a/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceCompileCoffeeScriptTask.groovy
+++ b/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceCompileCoffeeScriptTask.groovy
@@ -21,10 +21,9 @@ class WebResourceCompileCoffeeScriptTask extends TriremeBaseTask {
         project.afterEvaluate {
             extension = project.extensions.webResource
             pathResolver = new PathResolver(project, extension)
-            getInputs()
-                .files(pathResolver.retrieveValidSrcCoffeePaths())
-                .property('coffeeScript.minify', extension.coffeeScript?.minify)
-                .property('version', WebResourceExtension.VERSION)
+            getInputs().files(pathResolver.retrieveValidSrcCoffeePaths())
+            getInputs().property('coffeeScript.minify', extension.coffeeScript?.minify)
+            getInputs().property('version', WebResourceExtension.VERSION)
             getOutputs().files(pathResolver.retrieveValidPaths(pathResolver.getDestCoffee()))
             onlyIf {
                 project.file(pathResolver.resolveSrcPathFromProject(extension.coffeeScript?.src)).exists()

--- a/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceCompileLessTask.groovy
+++ b/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceCompileLessTask.groovy
@@ -21,10 +21,9 @@ class WebResourceCompileLessTask extends TriremeBaseTask {
         project.afterEvaluate {
             extension = project.extensions.webResource
             pathResolver = new PathResolver(project, extension)
-            getInputs()
-                .files(pathResolver.retrieveValidSrcLessPaths())
-                .property('less.minify', extension.less?.minify)
-                .property('version', WebResourceExtension.VERSION)
+            getInputs().files(pathResolver.retrieveValidSrcLessPaths())
+            getInputs().property('less.minify', extension.less?.minify)
+            getInputs().property('version', WebResourceExtension.VERSION)
             getOutputs().files(pathResolver.retrieveValidPaths(pathResolver.getDestLess()))
             onlyIf {
                 project.file(pathResolver.resolveSrcPathFromProject(extension.less?.src)).exists()

--- a/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceCopyBowerDependenciesTask.groovy
+++ b/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceCopyBowerDependenciesTask.groovy
@@ -16,10 +16,9 @@ class WebResourceCopyBowerDependenciesTask extends DefaultTask {
         project.afterEvaluate {
             extension = project.extensions.webResource
             pathResolver = new PathResolver(project, extension)
-            getInputs()
-                .dir(new File(extension.workDir, WebResourceInstallBowerDependenciesTask.BOWER_COMPONENTS_DIR))
-                .property('bower', extension.bower.toString())
-                .property('version', WebResourceExtension.VERSION)
+            getInputs().dir(new File(extension.workDir, WebResourceInstallBowerDependenciesTask.BOWER_COMPONENTS_DIR))
+            getInputs().property('bower', extension.bower.toString())
+            getInputs().property('version', WebResourceExtension.VERSION)
             getOutputs().files(pathResolver.retrieveValidDestLibPaths())
             onlyIf {
                 extension.bower.dependencies.size()

--- a/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceInstallBowerDependenciesTask.groovy
+++ b/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceInstallBowerDependenciesTask.groovy
@@ -16,10 +16,9 @@ class WebResourceInstallBowerDependenciesTask extends TriremeBaseTask {
         project.afterEvaluate {
             extension = project.extensions.webResource
             pathResolver = new PathResolver(project, extension)
-            getInputs()
-                .files(pathResolver.retrieveValidSrcLessPaths())
-                .property('bower', extension.bower.toString())
-                .property('version', WebResourceExtension.VERSION)
+            getInputs().files(pathResolver.retrieveValidSrcLessPaths())
+            getInputs().property('bower', extension.bower.toString())
+            getInputs().property('version', WebResourceExtension.VERSION)
             getOutputs().files(new File(extension.workDir, BOWER_COMPONENTS_DIR), getBowerScript())
             onlyIf {
                 extension.bower.dependencies.size()

--- a/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceTestCoffeeScriptTask.groovy
+++ b/src/main/groovy/com/github/ksoichiro/web/resource/task/WebResourceTestCoffeeScriptTask.groovy
@@ -21,10 +21,9 @@ class WebResourceTestCoffeeScriptTask extends TriremeBaseTask {
         project.afterEvaluate {
             extension = project.extensions.webResource
             pathResolver = new PathResolver(project, extension)
-            getInputs()
-                .files(pathResolver.retrieveValidSrcCoffeePaths())
-                .files(pathResolver.retrieveValidSrcTestCoffeePaths())
-                .property('version', WebResourceExtension.VERSION)
+            getInputs().files(pathResolver.retrieveValidSrcCoffeePaths())
+            getInputs().files(pathResolver.retrieveValidSrcTestCoffeePaths())
+            getInputs().property('version', WebResourceExtension.VERSION)
             getOutputs().files(pathResolver.retrieveValidPaths(pathResolver.getDestTestCoffee()))
             onlyIf {
                 project.file(pathResolver.resolveSrcPathFromProject(extension.coffeeScript?.src)).exists()


### PR DESCRIPTION
This fixes issue #16 

Rather than chaining properties for task inputs, this calls `getInputs().property(String,Object)` within each task that uses it.